### PR TITLE
Add vertical space to heading rule

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -35,6 +35,7 @@
     end: (97%, 0%),
     stroke: 2pt + gradient.linear(black, white),
   )
+  #v(15pt)
 ]
 
 #polylux-slide[

--- a/topics/context.typ
+++ b/topics/context.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == What is Nix?
-  #v(15pt)
 
   - just a programming language
   - functional

--- a/topics/flakes.typ
+++ b/topics/flakes.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == Flakes
-  #v(15pt)
 
   - extension to nixos/homemanager
   - removes the issue of hashes
@@ -15,7 +14,6 @@
 
 #polylux-slide[
   === Example
-  #v(15pt)
   #sourcecode(```nix
   {
     description = "dots";
@@ -50,7 +48,6 @@
 
 #polylux-slide[
   === Overrides
-  #v(15pt)
   #sourcecode(```nix
   new: old:
   {

--- a/topics/homemanager.typ
+++ b/topics/homemanager.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == Home-Manager
-  #v(15pt)
 
   - extension to nixos/nix-darwin
   - user level variant of nixos

--- a/topics/nix-lang.typ
+++ b/topics/nix-lang.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == What is Nix?
-  #v(15pt)
 
   - just a programming language
   - functional
@@ -18,7 +17,6 @@
 
 #polylux-slide[
   == Basics
-  #v(15pt)
 
   #columns(
     2,
@@ -35,13 +33,13 @@
       #colbreak()
       - native types
         - lists
-        - attribute set
+        - attribute sets
         - functions
         - numbers, strings, *paths*, etc
-      - inbuilt functionality
-        - import
-        - lib.toString
-        - std.mkDerivation
+      - built-in functionality
+        - `import`
+        - `lib.toString`
+        - `std.mkDerivation`
     ],
   )
   #pdfpc.speaker-note(```md
@@ -50,7 +48,6 @@
 
 #polylux-slide[
   == Tricks
-  #v(15pt)
   #columns(
     3,
     [
@@ -61,7 +58,7 @@
       in {
         func 24
       }
-      -- 48
+      # 48
       ```)
       - *only in this scope*
       #colbreak()
@@ -125,7 +122,6 @@
 
 #polylux-slide[
   == Packages
-  #v(15pt)
   #sourcecode(```nix
   { stdenv
   , lib
@@ -154,7 +150,7 @@
     ];
 
     meta = with lib; {
-      -- homepage, architecture support, help page etc
+      # homepage, architecture support, help page etc
     };
   }
   ```)

--- a/topics/nixos.typ
+++ b/topics/nixos.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == NixOS
-  #v(15pt)
 
   - a GNU/Linux distribution
   - fundamentally different file system design

--- a/topics/specializations.typ
+++ b/topics/specializations.typ
@@ -2,7 +2,6 @@
 
 #polylux-slide[
   == What else is Nix good for?
-  #v(15pt)
 
   - servers
     - declarative/reproducible server instantiation


### PR DESCRIPTION
- Add `#v(15pt)` to the global heading rule, so we don't need to add it for every slide
- Add some inline code blocks where appropriate
- Use `#` instead of `--` for nix comments